### PR TITLE
Example scene added

### DIFF
--- a/Example/Camera.tscn
+++ b/Example/Camera.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://rts-camera-godot/Scripts/move_node.gd" type="Script" id=1]
+[ext_resource path="res://rts-camera-godot/Scripts/tilt_node.gd" type="Script" id=2]
+[ext_resource path="res://rts-camera-godot/Scripts/camera.gd" type="Script" id=3]
+
+[node name="CameraMovement" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="CameraTilt" type="Spatial" parent="."]
+script = ExtResource( 2 )
+
+[node name="Camera" type="Camera" parent="CameraTilt"]
+script = ExtResource( 3 )
+

--- a/Example/Example.tscn
+++ b/Example/Example.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://rts-camera-godot/Example/Camera.tscn" type="PackedScene" id=1]
+
+[sub_resource type="CubeMesh" id=1]
+
+[node name="Root" type="Spatial"]
+
+[node name="Camera" parent="." instance=ExtResource( 1 )]
+
+[node name="Box" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -20 )
+mesh = SubResource( 1 )
+material/0 = null
+

--- a/Scripts/move_node.gd
+++ b/Scripts/move_node.gd
@@ -1,4 +1,4 @@
-extends Position3D
+extends Spatial
 
 export(float) var area_percent = 0.1
 export(int) var acc = 10

--- a/Scripts/tilt_node.gd
+++ b/Scripts/tilt_node.gd
@@ -1,4 +1,4 @@
-extends Position3D
+extends Spatial
 
 export(int) var ang_acc = 1
 export(int) var MAX_ANG_SPEED = 50


### PR DESCRIPTION
I added an basic example scene with a prebuild camera, so its easier to import and directly use it in other projects. And Position3D was changed to Spatial, because Position3D is only usefull for editing, but Movement/Tilt all have the same transform, so there isnt a need for viewing the position in editor.